### PR TITLE
Change XP rate indication message based on AlwaysEnabled config.

### DIFF
--- a/src/mod-double-xp-weekend.cpp
+++ b/src/mod-double-xp-weekend.cpp
@@ -63,9 +63,13 @@ public:
     {
         if (sConfigMgr->GetOption<bool>("XPWeekend.Announce", false))
         {
-            if (IsEventActive())
+            if (IsEventActive() && !sConfigMgr->GetOption<bool>("XPWeekend.AlwaysEnabled", false))
             {
-                ChatHandler(player->GetSession()).PSendSysMessage("It's the Weekend! Your XP rate has been set to: %u", GetExperienceRate(player));
+                ChatHandler(player->GetSession()).PSendSysMessage("It's the weekend! Your XP rate has been set to: %u", GetExperienceRate(player));
+            }
+            else if (IsEventActive() && sConfigMgr->GetOption<bool>("XPWeekend.AlwaysEnabled", false)
+            {
+                ChatHandler(player->GetSession()).PSendSysMessage("Your XP rate has been set to: %u", GetExperienceRate(player));
             }
             else
             {

--- a/src/mod-double-xp-weekend.cpp
+++ b/src/mod-double-xp-weekend.cpp
@@ -67,7 +67,7 @@ public:
             {
                 ChatHandler(player->GetSession()).PSendSysMessage("It's the weekend! Your XP rate has been set to: %u", GetExperienceRate(player));
             }
-            else if (IsEventActive() && sConfigMgr->GetOption<bool>("XPWeekend.AlwaysEnabled", false)
+            else if (IsEventActive() && sConfigMgr->GetOption<bool>("XPWeekend.AlwaysEnabled", false))
             {
                 ChatHandler(player->GetSession()).PSendSysMessage("Your XP rate has been set to: %u", GetExperienceRate(player));
             }


### PR DESCRIPTION
Currently it references the weekend even if the weekend doesn't play a part. This PR changes that.

Probably a better way to do it but I don't really feel like it.