### PR TITLE
Implement `.weekendxp config` command and allow rates to be `float`s

### DIFF
--- a/data/sql/db-world/mod-weekend-xp-texts.sql
+++ b/data/sql/db-world/mod-weekend-xp-texts.sql
@@ -2,7 +2,7 @@ SET @STRING_ENTRY := 11120;
 DELETE FROM `acore_string` WHERE `entry` IN  (@STRING_ENTRY+0,@STRING_ENTRY+1,@STRING_ENTRY+2);
 INSERT INTO `acore_string` (`entry`, `content_default`) VALUES
 (@STRING_ENTRY+0, 'Your experience rates were set to {}.'),
-(@STRING_ENTRY+1, 'Wrong value specified. Please specify a value between 1 and {}'),
+(@STRING_ENTRY+1, 'Wrong value specified. Please specify a value between 0 and {}'),
 (@STRING_ENTRY+2, 'The rate being applied to you is {}.\nThe current weekendxp configuration is:\nAnnounce {}\nAlwaysEnabled {}\nQuestOnly {}\nMaxLevel {}\nxpAmount {}\nIndividualXPEnabled {}\nEnabled {}\nMaxAllowedRate {}');
 
 DELETE FROM `command` WHERE `name` IN ('weekendxp rate');

--- a/data/sql/db-world/mod-weekend-xp-texts.sql
+++ b/data/sql/db-world/mod-weekend-xp-texts.sql
@@ -1,9 +1,14 @@
 SET @STRING_ENTRY := 11120;
-DELETE FROM `acore_string` WHERE `entry` IN  (@STRING_ENTRY+0,@STRING_ENTRY+1);
+DELETE FROM `acore_string` WHERE `entry` IN  (@STRING_ENTRY+0,@STRING_ENTRY+1,@STRING_ENTRY+2);
 INSERT INTO `acore_string` (`entry`, `content_default`) VALUES
-(@STRING_ENTRY+0, 'Your experience rates were set to %i.'),
-(@STRING_ENTRY+1, 'Wrong value specified. Please specify a value between 1 and %i');
+(@STRING_ENTRY+0, 'Your experience rates were set to {}.'),
+(@STRING_ENTRY+1, 'Wrong value specified. Please specify a value between 1 and {}'),
+(@STRING_ENTRY+2, 'The rate being applied to you is {}.\nThe current weekendxp configuration is:\nAnnounce {}\nAlwaysEnabled {}\nQuestOnly {}\nMaxLevel {}\nxpAmount {}\nIndividualXPEnabled {}\nEnabled {}\nMaxAllowedRate {}');
 
 DELETE FROM `command` WHERE `name` IN ('weekendxp rate');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('weekendxp rate', 0, 'Syntax: weekendxp rate $value \nSet your experience rate up to the allowed value.');
+
+DELETE FROM `command` WHERE `name` IN ('weekendxp config');
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+('weekendxp config', 0, 'Syntax: weekendxp config\nDisplays the current configuration for the weekendxp mod.');

--- a/src/mod-double-xp-weekend.cpp
+++ b/src/mod-double-xp-weekend.cpp
@@ -13,10 +13,198 @@ enum WeekendXP
 
     LANG_CMD_WEEKEND_XP_SET   = 11120,
     LANG_CMD_WEEKEND_XP_ERROR = 11121,
+    LANG_CMD_WEEKEND_XP_CONFIG = 11122,
 
     WD_FRIDAY   = 5,
     WD_SATURDAY = 6,
     WD_SUNDAY   = 0,
+};
+
+class DoubleXpWeekend
+{
+
+public:
+
+    DoubleXpWeekend() { }
+    
+    // NOTE We need to access the DoubleXpWeekend logic from other
+    // places, so keep all the logic accessible via a singleton here,
+    // and have the `CommandScript` and the `PlayeScript` access this
+    // for the functionality they need.
+    static DoubleXpWeekend* instance()
+    {
+        static DoubleXpWeekend instance;
+        return &instance;
+    }
+
+    uint32 OnGiveXP(Player* player, uint32 originalAmount, uint8 xpSource) const
+    {
+        if (!IsEventActive())
+        {
+            return originalAmount;
+        }
+
+        if (ConfigQuestOnly() && xpSource != PlayerXPSource::XPSOURCE_QUEST && xpSource != PlayerXPSource::XPSOURCE_QUEST_DF)
+        {
+            return originalAmount;
+        }
+
+        if (player->GetLevel() >= ConfigMaxLevel())
+        {
+            return originalAmount;
+        }
+
+        float newAmount = (float)originalAmount * GetExperienceRate(player);
+        return (uint32) newAmount;
+    }
+
+    void OnLogin(Player* player, ChatHandler* handler) const
+    {
+        if (ConfigAnnounce())
+        {
+            if (IsEventActive() && !ConfigAlwaysEnabled())
+            {
+                float rate = GetExperienceRate(player);
+                // TODO not sure why some strings were defined in SQL scripts and others (like these)
+                // are inlined here. Potentially we might want to move this to an SQL script as well
+                // (for consistency at least...)
+                handler->PSendSysMessage("It's the weekend! Your XP rate has been set to: {}", rate);
+            }
+            else if (IsEventActive() && ConfigAlwaysEnabled())
+            {
+                float rate = GetExperienceRate(player);
+                handler->PSendSysMessage("Your XP rate has been set to: {}", rate);
+            }
+            else
+            {
+                handler->PSendSysMessage("This server is running the |cff4CFF00Double XP Weekend |rmodule.");
+            }
+        }
+    }
+
+    bool HandleSetXPBonusCommand(ChatHandler* handler, float rate) const
+    {
+        Player* player = handler->GetPlayer();
+
+        float maxRate = ConfigMaxAllowedRate();
+
+        if (rate <= 0.0f || rate > maxRate)
+        {
+            handler->PSendSysMessage(LANG_CMD_WEEKEND_XP_ERROR, maxRate);
+            handler->SetSentErrorMessage(true);
+            return true;
+        }
+
+        PlayerSettingSetRate(player, rate);
+        handler->PSendSysMessage(LANG_CMD_WEEKEND_XP_SET, rate);
+
+        return true;
+    }
+
+    bool HandleGetCurrentConfigCommand(ChatHandler* handler) const
+    {
+        Player* player = handler->GetPlayer();
+
+        const float actualRate = GetExperienceRate(player);
+        const bool isAnnounceEnabled = ConfigAnnounce();
+        const bool isAlwaysEnabled = ConfigAlwaysEnabled();
+        const bool isQuestOnly = ConfigQuestOnly();
+        const uint32 maxLevel = ConfigMaxLevel();
+        const float xpRate = ConfigxpAmount();
+        const bool isIndividulaXpEnabled = ConfigIndividualXPEnabled();
+        const bool isEnabled = ConfigEnabled();
+        const float maxXpRate = ConfigMaxAllowedRate();
+
+        handler->PSendSysMessage(LANG_CMD_WEEKEND_XP_CONFIG,
+            actualRate,
+            isAnnounceEnabled,
+            isAlwaysEnabled,
+            isQuestOnly,
+            maxLevel,
+            xpRate,
+            isIndividulaXpEnabled,
+            isEnabled,
+            maxXpRate
+        );
+
+        return true;
+    }
+
+private:
+
+    // NOTE keep options together to prevent having more than 1 potential default value
+    bool ConfigAlwaysEnabled() const { return sConfigMgr->GetOption<bool>("XPWeekend.AlwaysEnabled", false); }
+    bool ConfigAnnounce() const { return sConfigMgr->GetOption<bool>("XPWeekend.Announce", false); }
+    bool ConfigQuestOnly() const { return sConfigMgr->GetOption<bool>("XPWeekend.QuestOnly", false); }
+    uint32 ConfigMaxLevel() const { return sConfigMgr->GetOption<uint32>("XPWeekend.MaxLevel", 80); }
+    float ConfigxpAmount() const { return sConfigMgr->GetOption<float>("XPWeekend.xpAmount", 2.0f); }
+    bool ConfigIndividualXPEnabled() const { return sConfigMgr->GetOption<bool>("XPWeekend.IndividualXPEnabled", false); }
+    bool ConfigEnabled() const { return sConfigMgr->GetOption<bool>("XPWeekend.Enabled", false); }
+    float ConfigMaxAllowedRate() const { return sConfigMgr->GetOption<float>("XPWeekend.MaxAllowedRate", 2.0f); }
+
+    void PlayerSettingSetRate(Player* player, float rate) const
+    {
+        // HACK PlayerSetting seems to store uint32 only, so save our `float`
+        // as if it was a `uint32`, and when getting it back use the same trick.
+        // This **should** be fine (?) as long as `PlayerSetting::value` is a `uint32` and rate a `float`
+        uint32 rateStorage;
+        memcpy(&rateStorage, &rate, sizeof(uint32));
+        player->UpdatePlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_RATE, rateStorage);
+    }
+    
+    float PlayerSettingGetRate(Player* player) const
+    {
+        // HACK check `PlayerSettingSetRate` for context
+        uint32 rateStored = player->GetPlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_RATE).value;
+        if (rateStored == 0) return 0.0f;
+        
+        float rate;
+        memcpy(&rate, &rateStored, sizeof(uint32));
+        return rate;
+    }
+    
+    // TODO why is there a `GetDisable` player setting but no way to actually modify it? Leaving as is for now...
+    bool PlayerSettingGetDisable(Player* player) const
+    {
+        return player->GetPlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_DISABLE).value == (uint32)1;
+    }
+
+    float GetExperienceRate(Player* player) const
+    {
+        float rate = ConfigxpAmount();
+
+        if (PlayerSettingGetDisable(player))
+        {
+            return 1.0f;
+        }
+
+        // If individualxp setting is enabled... and a rate was set, overwrite it.
+        if (ConfigIndividualXPEnabled())
+        {
+            rate = PlayerSettingGetRate(player);
+        }
+
+        // Prevent returning 0% rate.
+        return rate > 0.0f ? rate : 1.0f;
+    }
+
+    bool IsEventActive() const
+    {
+        if (ConfigAlwaysEnabled())
+        {
+            return true;
+        }
+            
+        if (!ConfigEnabled())
+        {
+            return false;
+        }
+
+        time_t t = time(nullptr);
+        tm* now = localtime(&t);
+
+        return now->tm_wday == WD_FRIDAY || now->tm_wday == WD_SATURDAY || now->tm_wday == WD_SUNDAY;
+    }
 };
 
 class weekendxp_commandscript : public CommandScript
@@ -29,113 +217,47 @@ public:
         static ChatCommandTable commandTable =
         {
             { "weekendxp rate", HandleSetXPBonusCommand, SEC_PLAYER, Console::No },
+            { "weekendxp config", HandleGetCurrentConfigCommand, SEC_PLAYER, Console::No },
         };
 
         return commandTable;
     }
 
-    static bool HandleSetXPBonusCommand(ChatHandler* handler, int8 rate)
+    static bool HandleSetXPBonusCommand(ChatHandler* handler, float rate)
     {
-        Player* player = handler->GetPlayer();
+        DoubleXpWeekend* mod = DoubleXpWeekend::instance();
+        return mod->HandleSetXPBonusCommand(handler, rate);
+    }
 
-        int8 maxRate = sConfigMgr->GetOption<int8>("XPWeekend.MaxAllowedRate", 2);
-
-        if (rate <= 0 || rate > maxRate)
-        {
-            handler->PSendSysMessage(LANG_CMD_WEEKEND_XP_ERROR, maxRate);
-            handler->SetSentErrorMessage(true);
-            return true;
-        }
-
-        player->UpdatePlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_RATE, rate);
-        handler->PSendSysMessage(LANG_CMD_WEEKEND_XP_SET, rate);
-
-        return true;
+    static bool HandleGetCurrentConfigCommand(ChatHandler* handler)
+    {
+        DoubleXpWeekend* mod = DoubleXpWeekend::instance();
+        return mod->HandleGetCurrentConfigCommand(handler);
     }
 };
 
-class DoubleXpWeekend : public PlayerScript
+class DoubleXpWeekendPlayerScript : public PlayerScript
 {
 public:
-    DoubleXpWeekend() : PlayerScript("DoubleXpWeekend") { }
+    DoubleXpWeekendPlayerScript() : PlayerScript("DoubleXpWeekend") { }
 
     void OnLogin(Player* player) override
     {
-        if (sConfigMgr->GetOption<bool>("XPWeekend.Announce", false))
-        {
-            if (IsEventActive() && !sConfigMgr->GetOption<bool>("XPWeekend.AlwaysEnabled", false))
-            {
-                ChatHandler(player->GetSession()).PSendSysMessage("It's the weekend! Your XP rate has been set to: {}", GetExperienceRate(player));
-            }
-            else if (IsEventActive() && sConfigMgr->GetOption<bool>("XPWeekend.AlwaysEnabled", false))
-            {
-                ChatHandler(player->GetSession()).PSendSysMessage("Your XP rate has been set to: {}", GetExperienceRate(player));
-            }
-            else
-            {
-                ChatHandler(player->GetSession()).PSendSysMessage("This server is running the |cff4CFF00Double XP Weekend |rmodule.");
-            }
-        }
+        DoubleXpWeekend* mod = DoubleXpWeekend::instance();
+        ChatHandler handler = ChatHandler(player->GetSession());
+        mod->OnLogin(player, &handler);
     }
 
     void OnGiveXP(Player* player, uint32& amount, Unit* /*victim*/, uint8 xpSource) override
     {
-        if (!IsEventActive())
-        {
-            return;
-        }
-
-        if (sConfigMgr->GetOption<bool>("XPWeekend.QuestOnly", false) && xpSource != PlayerXPSource::XPSOURCE_QUEST && xpSource != PlayerXPSource::XPSOURCE_QUEST_DF)
-        {
-            return;
-        }
-
-        if (player->GetLevel() >= sConfigMgr->GetOption<uint32>("XPWeekend.MaxLevel", 80))
-        {
-            return;
-        }
-
-        amount *= GetExperienceRate(player);
+        DoubleXpWeekend* mod = DoubleXpWeekend::instance();
+        amount = mod->OnGiveXP(player, amount, xpSource);
     }
 
-    int8 GetExperienceRate(Player * player) const
-    {
-        int8 rate = sConfigMgr->GetOption<int8>("XPWeekend.xpAmount", 2);
-
-        int8 individualRate = player->GetPlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_RATE).value;
-
-        if (player->GetPlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_DISABLE).value)
-        {
-            return 1;
-        }
-
-        // If individualxp setting is enabled... and a rate was set, overwrite it.
-        if (sConfigMgr->GetOption<bool>("XPWeekend.IndividualXPEnabled", false) && individualRate)
-        {
-            rate = individualRate;
-        }
-
-        // Prevent returning 0% rate.
-        return rate ? rate : 1;
-    }
-
-    bool IsEventActive() const
-    {
-        if (sConfigMgr->GetOption<bool>("XPWeekend.AlwaysEnabled", false))
-            return true;
-            
-        if (!sConfigMgr->GetOption<bool>("XPWeekend.Enabled", false))
-            return false;
-
-        time_t t = time(nullptr);
-        tm* now = localtime(&t);
-
-        return now->tm_wday == WD_FRIDAY || now->tm_wday == WD_SATURDAY || now->tm_wday == WD_SUNDAY;
-    }
 };
 
 void AdddoublexpScripts()
 {
-    new DoubleXpWeekend();
+    new DoubleXpWeekendPlayerScript();
     new weekendxp_commandscript();
 }

--- a/src/mod-double-xp-weekend.cpp
+++ b/src/mod-double-xp-weekend.cpp
@@ -25,19 +25,6 @@ class DoubleXpWeekend
 {
 
 public:
-
-    // - CHANGELOG -
-    // Version 1:
-    // * Now rates are handled as `float`s as opposed to `uint32`. The SETTING_WEEKEND_XP_RATE does technically
-    //   store an `uint32`, but we are just storing a float in there, hence the hacky reinterpreting code you see around
-    // * Introduced command `.weekendxp config`. The mod is already confusing as it is, and without knowing the currently
-    //   running configuration file, players have no way to know what is going on with the xp rate. This command should
-    //   help with that
-    // * Moved all the mod-related logic to it's own class, accessible through `DoubleXpWeekend* DoubleXpWeekend::instance()`.
-    //   That way both the `CommandScript` and the `PlayerScript` can rely on the same logic.
-    // * Introduced the concept of migrations, since different versions of the mod (like this one), might change how things
-    //   work, and some persistent data might need to be changed in some way. For now this only migrates the player settings
-    //   on login.
     
     DoubleXpWeekend() { }
     
@@ -84,9 +71,6 @@ public:
             if (IsEventActive() && !ConfigAlwaysEnabled())
             {
                 float rate = GetExperienceRate(player);
-                // TODO not sure why some strings were defined in SQL scripts and others (like these)
-                // are inlined here. Potentially we might want to move this to an SQL script as well
-                // (for consistency at least...)
                 handler->PSendSysMessage("It's the weekend! Your XP rate has been set to: {}", rate);
             }
             else if (IsEventActive() && ConfigAlwaysEnabled())


### PR DESCRIPTION
* Now rates are handled as `float`s as opposed to `uint32`. The `SETTING_WEEKEND_XP_RATE` does technically store an `uint32`, but we are just storing a float in there, hence the hacky reinterpreting code you see around. This should be fine as long as the player settings value type is not changed. This means that setting the rate to `0.5` for a "half xp mode" is now possible, so I changed the previously hardcoded minimum rate from `1` to `0`.
* Introduced command `.weekendxp config`. The mod is already confusing as it is, and without knowing the configuration file's contents, players have no way to know what is going on with the xp rate. This command should help with that.
* Moved all the mod-related logic to it's own class, accessible through `DoubleXpWeekend* DoubleXpWeekend::instance()`, I saw the transmog mod do something like this as well. That way both the `CommandScript` and the `PlayerScript` can rely on the same logic.
* Introduced the concept of migrations, since different versions of the mod (like this one), might change how things work, and some persistent data might need to be changed in some way. For now this only migrates the player settings.

Also changed the existing strings to use `{}` rather than the c-like formatters, since they seemed to not work in `master`, not sure what that is about. (Edit: It seems this was a recent change to the server to how the string formatting worked, so that's all good now)

~I haven't yet checked that players that have set their personal rate on previous versions will have no problem after updating. I expect it to potentially be problematic, since I'm reusing the personal rate setting to be a `float` in a very hacky way. A simple solution is to make a new `PlayerSetting` that contains the last used version of the mod, and based on it, "migrate" the old player settings. Will test this soon (not now since docker just decided to crash and its late) and hopefully we can get this accepted.~ Migration is now implemented and players that had previously set a personal rate don't need to do anything, it is kept.

- This closes #28.
- Also closes https://github.com/chromiecraft/chromiecraft/discussions/5122.