### PR TITLE
Add Joyous Journeys event support to double XP module

### DIFF
--- a/conf/mod-double-xp-weekend.conf.dist
+++ b/conf/mod-double-xp-weekend.conf.dist
@@ -59,3 +59,28 @@ XPWeekend.MaxLevel = 80
 #     Default: 0 (Disabled)
 
 XPWeekend.IsDKStartZoneRequired = 0
+
+# XPWeekend.IsJoyousJourneysActive = 0
+#     Promotional event, adds yet another layer of bonus on top of the current bonus (yay!)
+#     Default: 0 (Disabled)
+
+XPWeekend.IsJoyousJourneysActive = 0
+
+# XPWeekend.JoyousJourneysXPRate = 1
+#     Bonus experience rate during joyous journeys.
+#     ADDS to the base one. So if base 2x + 1x from this = 3x (50% increase).
+#     Default: 1
+
+XPWeekend.JoyousJourneysXPRate = 1
+
+# XPWeekend.JoyousJourneysRepRate = 1.10
+#     Reputation bonus while joyous journeys is active.
+#     Default: 1.10 (10%)
+
+XPWeekend.JoyousJourneysRepRate = 1.10
+
+# XPWeekend.ExcludeInsaneReps = 1
+#     Exclude the insane title reputations e.g ravenholdt
+#     Default: 1 (Enabled)
+
+XPWeekend.ExcludeInsaneReps = 1


### PR DESCRIPTION
Introduces configuration options and logic for the Joyous Journeys promotional event, including additional XP and reputation rate modifiers and an option to exclude certain reputations. Updates both the configuration file and the module code to support enabling/disabling the event and customizing its effects.