### PR TITLE
Sync player setting when capping XP rate

### DIFF
--- a/src/mod-double-xp-weekend.cpp
+++ b/src/mod-double-xp-weekend.cpp
@@ -243,7 +243,10 @@ private:
 
             // If config changed, cap it to max allowed
             if (rate > ConfigMaxAllowedRate())
+            {
                 rate = ConfigMaxAllowedRate();
+                player->UpdatePlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_RATE, ConfigMaxAllowedRate());
+            }
         }
 
         if (IsJoyousJourneysActive() && !player->GetPlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_JOYOUS_JOURNEYS).IsEnabled())


### PR DESCRIPTION
When the XP rate exceeds the configured maximum, the player's setting is now updated to reflect the capped value. This ensures consistency between the applied rate and the stored player setting.