### PR TITLE
Add Steemwhedle Cartel to double XP factions exception

### DIFF
--- a/src/mod-double-xp-weekend.cpp
+++ b/src/mod-double-xp-weekend.cpp
@@ -360,6 +360,7 @@ public:
                 case 349: // Ravenholdt
                 case 87:  // bloodsail bucaneers
                 case 21:  // Booty Bay
+                case 169: // Steemwhedle Cartel
                 case 577: // Everlook
                 case 369: // Gadgetzan
                 case 470: // Ratchet


### PR DESCRIPTION
Included faction ID 169 (Steemwhedle Cartel) in the list of factions not affected by double XP weekend.