### PR TITLE
Exclude battlegrounds from Joyous Journeys XP bonus

### DIFF
--- a/src/mod-double-xp-weekend.cpp
+++ b/src/mod-double-xp-weekend.cpp
@@ -251,7 +251,8 @@ private:
 
         if (IsJoyousJourneysActive() && !player->GetPlayerSetting("mod-double-xp-weekend", SETTING_WEEKEND_XP_JOYOUS_JOURNEYS).IsEnabled())
         {
-            rate += ConfigJoyousJourneysXPRate();
+            if (!player->GetMap()->IsBattlegroundOrArena())
+                rate += ConfigJoyousJourneysXPRate();
         }
 
         // Prevent returning 0% rate.


### PR DESCRIPTION
Adjusted the XP rate calculation to prevent the Joyous Journeys XP bonus from being applied in battlegrounds or arenas.